### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,6 @@
 name: E2E Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/rag/security/code-scanning/21](https://github.com/bniladridas/rag/security/code-scanning/21)

To fix the issue, add a `permissions` block near the top-level of the workflow, just beneath the workflow name and above the `jobs:` block. The minimal recommended permissions for most CI/test workflows are `contents: read`, which grants only read permissions to the repository contents via the GITHUB_TOKEN. If any job required further permissions (e.g., opening PRs or managing releases), those could be added; however, based on the jobs/steps shown, `contents: read` suffices. The change should be a single addition:

- Insert the following block after the workflow name (after line 1, before line 2 or 3):
  ```
  permissions:
    contents: read
  ```

No code logic or existing workflow steps need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
