### PR TITLE
Potential fix for code scanning alert no. 23: Code injection

### DIFF
--- a/.github/workflows/dependabot-analyzer.yml
+++ b/.github/workflows/dependabot-analyzer.yml
@@ -37,6 +37,8 @@ jobs:
       # ============================================================
       - name: Determine if should run
         id: should-run
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           # Check if triggered by workflow_dispatch
           if [ "${{ github.event_name }}" == "workflow_dispatch" ] &&
@@ -49,7 +51,6 @@ jobs:
 
           # Check if triggered by issue_comment with "/analyze"
           if [ "${{ github.event_name }}" == "issue_comment" ]; then
-            COMMENT_BODY="${{ github.event.comment.body }}"
             if echo "$COMMENT_BODY" | grep -qiE "^\/(analyze|run analysis|check pr)"; then
               echo "RUN=true" >> $GITHUB_OUTPUT
               echo "PR_NUMBER=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/rag/security/code-scanning/23](https://github.com/bniladridas/rag/security/code-scanning/23)

To fix the problem, move the untrusted expression `${{ github.event.comment.body }}` out of the script body and into an environment variable using `env:`, then reference that variable inside the script using plain shell syntax (`$COMMENT_BODY`). This ensures that the user-controlled value is never interpreted as part of the script source; it is only read as data by the shell.

Concretely, in `.github/workflows/dependabot-analyzer.yml`, edit the “Determine if should run” step (lines 38–60). Add an `env:` section to the step that defines `COMMENT_BODY: ${{ github.event.comment.body }}`. Then change the assignment on line 52 from `COMMENT_BODY="${{ github.event.comment.body }}"` to simply using the environment variable already provided, e.g. `if echo "$COMMENT_BODY" | grep ...`. Since the only use of `COMMENT_BODY` is in the `grep` pipeline, we can remove the explicit assignment entirely and rely on the environment variable. No new methods or external libraries are required; this is purely a YAML/workflow change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal workflow optimization—no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->