### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/travis.yml
+++ b/.github/workflows/travis.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.10'
   PIP_CACHE_DIR: ~/.pip


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/rag/security/code-scanning/24](https://github.com/bniladridas/rag/security/code-scanning/24)

In general, the fix is to explicitly declare the minimal required `GITHUB_TOKEN` permissions using a `permissions:` block either at the workflow root (applying to all jobs) or per job. Since this workflow only needs to read the repository contents and does not modify GitHub resources, we can safely restrict the token to `contents: read`. This documents the workflow’s needs and ensures least privilege even if repository defaults change.

The best way to fix this without changing existing functionality is to add a single top-level `permissions:` block after the `on:` section, setting `contents: read`. All existing jobs (`test`, `lint`, `notify`, `allowed-failures`) will then inherit these permissions, and none of their steps rely on higher privileges. No additional methods, imports, or definitions are needed because this is purely a YAML configuration change within `.github/workflows/travis.yml`.

Concretely: in `.github/workflows/travis.yml`, between the `on:` block (lines 3–7) and the `env:` block (lines 9–12), insert:

```yaml
permissions:
  contents: read
```

leaving the rest of the file unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance permissions management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->